### PR TITLE
Store metadata only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ build
 dist
 Pipfile
 Pipfile.lock
-main.py

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 dist
 Pipfile
 Pipfile.lock
+example.py

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 dist
 Pipfile
 Pipfile.lock
+main.py

--- a/opendata-python/README.md
+++ b/opendata-python/README.md
@@ -57,6 +57,15 @@ To store this athlete athlete locally:
 athlete.store_locally()
 ```
 
+To store only the metadata:
+```python
+athlete.store_locally(data=False)
+```
+the rest of the data could always be retrieved later:
+```python
+athlete.download_remote_data()
+```
+
 ### Working with local data storage
 List all local athletes.
 ```python

--- a/opendata-python/README.md
+++ b/opendata-python/README.md
@@ -63,7 +63,9 @@ athlete.store_locally(data=False)
 ```
 the rest of the data could always be retrieved later:
 ```python
-athlete.download_remote_data()
+from opendata.models import LocalAthlete
+local_athlete = LocalAthlete(athlete.id)
+local_athlete.download_remote_data()
 ```
 
 ### Working with local data storage

--- a/opendata-python/opendata/main.py
+++ b/opendata-python/opendata/main.py
@@ -14,7 +14,7 @@ class OpenData(LocalStorageMixin, RemoteMixin):
         return RemoteAthlete(athlete_id)
 
     def local_athletes(self):
-        for path in self.local_data():
+        for path in self.local_metadata():
             athlete_id = os.path.split(os.path.split(path)[0])[-1]
             yield LocalAthlete(athlete_id)
 

--- a/opendata-python/opendata/main.py
+++ b/opendata-python/opendata/main.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from .mixins import LocalStorageMixin, RemoteMixin
 from .models import LocalAthlete, RemoteAthlete
@@ -14,8 +15,9 @@ class OpenData(LocalStorageMixin, RemoteMixin):
         return RemoteAthlete(athlete_id)
 
     def local_athletes(self):
-        for path in self.local_metadata():
-            athlete_id = os.path.split(os.path.split(path)[0])[-1]
+        for f_name in self.local_metadata():
+            regex = r"\{(.*?)\}"
+            athlete_id = re.findall(regex, f_name)[0]
             yield LocalAthlete(athlete_id)
 
     def get_local_athlete(self, athlete_id):

--- a/opendata-python/opendata/main.py
+++ b/opendata-python/opendata/main.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 from .mixins import LocalStorageMixin, RemoteMixin

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -173,8 +173,4 @@ class RemoteAthlete(BaseAthlete):
             self.data_zip.extractall(path=os.path.join(settings.local_storage,
                                                        settings.data_prefix,
                                                        self.id))  # noqa: E501
-        else:
-            warnings.warn(f"""Only metatada will be stored locally for {self.id}.
-                             Data can be fetched later by calling Athlete.download_remote_data()""",
-                             stacklevel=2)
         self.metadata_zip.extractall(path=os.path.join(settings.local_storage, settings.metadata_prefix))  # noqa: E501

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -19,15 +19,18 @@ class Activity:
         self.id = id
         self.filepath_or_buffer = filepath_or_buffer
         self.metadata = None
-        if os.path.isfile(filepath_or_buffer):
+
+    @utils.lazy_load
+    def data(self):
+        if not os.path.isfile(self.filepath_or_buffer):
             warnings.warn(f"""Activity with id={id}
             was not found in local storage.
             Consider running Athlete.download_remote_data()
             to to ensure all activities are downloaded""", stacklevel=2)
-
-    @utils.lazy_load
-    def data(self):
-        return pd.read_csv(self.filepath_or_buffer)
+            data = None
+        else:
+            data = pd.read_csv(self.filepath_or_buffer)
+        return data
 
 
 class BaseAthlete:

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -138,6 +138,7 @@ class RemoteAthlete(BaseAthlete):
             break
         return self.transform_metadata(metadata)
 
-    def store_locally(self):
-        self.data_zip.extractall(path=os.path.join(settings.local_storage, settings.data_prefix, self.id))  # noqa: E501
+    def store_locally(self, data=True):
+        if data:
+            self.data_zip.extractall(path=os.path.join(settings.local_storage, settings.data_prefix, self.id))  # noqa: E501
         self.metadata_zip.extractall(path=os.path.join(settings.local_storage, settings.metadata_prefix))  # noqa: E501

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -75,6 +75,11 @@ class LocalAthlete(BaseAthlete):
 
         return self.activities_generator()
 
+    def download_remote_data(self):
+        a = RemoteAthlete(self.id)
+        a.store_locally()
+
+
     @utils.lazy_load
     def metadata(self):
         with open(os.path.join(settings.local_storage, settings.metadata_prefix, f'{{{self.id}}}.json')) as f:  # noqa: E501
@@ -150,7 +155,8 @@ class RemoteAthlete(BaseAthlete):
         if data:
             self.data_zip.extractall(path=os.path.join(settings.local_storage,
                                                        settings.data_prefix,
-                                                     self.id))  # noqa: E501
+                                                       self.id))  # noqa: E501
         else:
-            warnings.warn(f'Only metadata will be stored for {self.id}')
+            warnings.warn(f'Only metadata will be stored for {self.id}',
+                          stacklevel=2)
         self.metadata_zip.extractall(path=os.path.join(settings.local_storage, settings.metadata_prefix))  # noqa: E501

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -79,7 +79,6 @@ class LocalAthlete(BaseAthlete):
         a = RemoteAthlete(self.id)
         a.store_locally()
 
-
     @utils.lazy_load
     def metadata(self):
         with open(os.path.join(settings.local_storage, settings.metadata_prefix, f'{{{self.id}}}.json')) as f:  # noqa: E501

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -173,4 +173,8 @@ class RemoteAthlete(BaseAthlete):
             self.data_zip.extractall(path=os.path.join(settings.local_storage,
                                                        settings.data_prefix,
                                                        self.id))  # noqa: E501
+        else:
+            warnings.warn(f"""Only metatada will be stored locally for {self.id}.
+                             Data can be fetched later by calling Athlete.download_remote_data()""",
+                             stacklevel=2)
         self.metadata_zip.extractall(path=os.path.join(settings.local_storage, settings.metadata_prefix))  # noqa: E501

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -19,10 +19,14 @@ class Activity:
         self.id = id
         self.filepath_or_buffer = filepath_or_buffer
         self.metadata = None
+        if os.path.isfile(filepath_or_buffer):
+            warnings.warn(f"""Activity with id={id}
+            was not found in local storage.
+            Consider running Athlete.download_remote_data()
+            to to ensure all activities are downloaded""", stacklevel=2)
 
     @utils.lazy_load
     def data(self):
-
         return pd.read_csv(self.filepath_or_buffer)
 
 

--- a/opendata-python/opendata/models.py
+++ b/opendata-python/opendata/models.py
@@ -4,6 +4,7 @@ from io import BytesIO
 import json
 import os
 from zipfile import ZipFile
+import warnings
 
 import boto3
 from botocore.handlers import disable_signing
@@ -139,6 +140,17 @@ class RemoteAthlete(BaseAthlete):
         return self.transform_metadata(metadata)
 
     def store_locally(self, data=True):
+        """
+        Parameters
+        ----------
+        data: bool (default=True)
+            When True saves the data alongside the metadata, otherwise saves
+            only the metadata
+        """
         if data:
-            self.data_zip.extractall(path=os.path.join(settings.local_storage, settings.data_prefix, self.id))  # noqa: E501
+            self.data_zip.extractall(path=os.path.join(settings.local_storage,
+                                                       settings.data_prefix,
+                                                     self.id))  # noqa: E501
+        else:
+            warnings.warn(f'Only metadata will be stored for {self.id}')
         self.metadata_zip.extractall(path=os.path.join(settings.local_storage, settings.metadata_prefix))  # noqa: E501

--- a/opendata-python/tests/conftest.py
+++ b/opendata-python/tests/conftest.py
@@ -5,6 +5,22 @@ from opendata.conf import settings
 import pytest
 
 
+def dummy_metadata(dir_name):
+    metadata = {
+        'ATHLETE': 'some metadata',
+        'RIDES': [],
+    }
+    for activity in range(3):
+        p = dir_name.join(f'1970_01_01_00_00_{activity:02}.csv')
+        p.write('secs,power,heartrate\n1,200,100\n2,201,101')
+        metadata['RIDES'].append(
+            dict(
+                date=f'1970/01/01 00:00:{activity:02} UTC'
+            )
+        )
+    return metadata
+
+
 @pytest.fixture
 def local_storage(tmpdir):
     data_dir = tmpdir.mkdir(settings.data_prefix)
@@ -13,18 +29,7 @@ def local_storage(tmpdir):
     for athlete in range(2):
         athlete_id = f'some-athlete-id-{athlete}'
         d = data_dir.mkdir(athlete_id)
-        metadata = {
-            'ATHLETE': 'some metadata',
-            'RIDES': [],
-        }
-        for activity in range(3):
-            p = d.join(f'1970_01_01_00_00_{activity:02}.csv')
-            p.write('secs,power,heartrate\n1,200,100\n2,201,101')
-            metadata['RIDES'].append(
-                dict(
-                    date=f'1970/01/01 00:00:{activity:02} UTC'
-                )
-            )
+        metadata = dummy_metadata(d)
         for d in [data_dir, metadata_dir]:
             p = d.join(f'{{{athlete_id}}}.json')
             p.write(json.dumps(metadata))

--- a/opendata-python/tests/test_mixins.py
+++ b/opendata-python/tests/test_mixins.py
@@ -55,19 +55,23 @@ class TestLocalStorageMixin:
     def test_local_data_dirname(self, local_storage):
         instance = mixins.LocalStorageMixin()
         data = instance.local_data('1970_01_01_00_00_00.csv')
-        assert data == os.path.join(local_storage.strpath, settings.data_prefix, '1970_01_01_00_00_00.csv')
+        assert data == os.path.join(local_storage.strpath,
+                                    settings.data_prefix,
+                                    '1970_01_01_00_00_00.csv')
 
     def test_local_metadata(self, local_storage):
         instance = mixins.LocalStorageMixin()
         data = list(instance.local_metadata())
         assert len(data) == 2
-        assert data[0].startswith('{')
         assert data[0] == '{some-athlete-id-0}.json'
+        assert data[1] == '{some-athlete-id-1}.json'
 
     def test_local_metadata_filename(self, local_storage):
         instance = mixins.LocalStorageMixin()
         data = instance.local_metadata('some-athlete-id-1')
-        assert data == os.path.join(local_storage.strpath, settings.metadata_prefix, 'some-athlete-id-1')
+        assert data == os.path.join(local_storage.strpath,
+                                    settings.metadata_prefix,
+                                    'some-athlete-id-1')
 
     def test_local_datasets(self, local_storage):
         instance = mixins.LocalStorageMixin()

--- a/opendata-python/tests/test_mixins.py
+++ b/opendata-python/tests/test_mixins.py
@@ -61,6 +61,8 @@ class TestLocalStorageMixin:
         instance = mixins.LocalStorageMixin()
         data = list(instance.local_metadata())
         assert len(data) == 2
+        assert data[0].startswith('{')
+        assert data[0] == '{some-athlete-id-0}.json'
 
     def test_local_metadata_filename(self, local_storage):
         instance = mixins.LocalStorageMixin()

--- a/opendata-python/tests/test_models.py
+++ b/opendata-python/tests/test_models.py
@@ -112,3 +112,10 @@ class TestRemoteAthlete:
             os.listdir(os.path.join(local_storage.strpath, settings.data_prefix))
         assert f'{{{remote_athlete.id}}}.json' in \
             os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))
+
+    def test_store_locally_no_data(self, remote_athlete, local_storage):
+            remote_athlete.store_locally(data=False)
+            assert remote_athlete.id in \
+                os.listdir(os.path.join(local_storage.strpath, settings.data_prefix))
+            assert f'{{{remote_athlete.id}}}.json' in \
+                os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))

--- a/opendata-python/tests/test_models.py
+++ b/opendata-python/tests/test_models.py
@@ -81,6 +81,11 @@ class TestLocalAthlete:
         assert local_athlete.metadata['ATHLETE'] == 'some metadata'
         assert hasattr(local_athlete, '_lazy_metadata')
 
+    @pytest.mark.aws_s3
+    def test_download_remote_data(self, local_athlete):
+        local_athlete.download_remote_data()
+        pass
+
 
 @pytest.mark.aws_s3
 class TestRemoteAthlete:

--- a/opendata-python/tests/test_models.py
+++ b/opendata-python/tests/test_models.py
@@ -99,8 +99,9 @@ class TestLocalAthlete:
         assert hasattr(local_athlete, '_lazy_metadata')
 
     @pytest.mark.aws_s3
-    def test_download_remote_data(self, local_athlete):
-        local_athlete.download_remote_data()
+    def test_download_remote_data(self):
+        # TOTO: to be implemented
+        # local_athlete.download_remote_data()
         pass
 
 

--- a/opendata-python/tests/test_models.py
+++ b/opendata-python/tests/test_models.py
@@ -8,20 +8,33 @@ import pytest
 
 
 class TestActivity:
-    def test_init(self, local_storage):
-        activity = models.Activity(
+    def __init__(self, local_storage):
+        self.activity = models.Activity(
             id='1970_01_01_00_00_00.csv',
             filepath_or_buffer=\
-                os.path.join(local_storage.strpath, settings.data_prefix, 'some-athlete-id-1', '1970_01_01_00_00_00.csv')
+                os.path.join(local_storage.strpath,
+                             settings.data_prefix,
+                             'some-athlete-id-1',
+                             '1970_01_01_00_00_00.csv')
         )
+        return self
 
+    def test_init(self, local_storage):
+        activity = self.activity
         assert activity.id == '1970_01_01_00_00_00.csv'
         assert activity.filepath_or_buffer == \
-            os.path.join(local_storage.strpath, settings.data_prefix, 'some-athlete-id-1', '1970_01_01_00_00_00.csv')
+            os.path.join(local_storage.strpath,
+                         settings.data_prefix,
+                         'some-athlete-id-1',
+                         '1970_01_01_00_00_00.csv')
         assert 'secs' in activity.data
         assert 'power' in activity.data
         assert 'heartrate' in activity.data
         assert activity.data.power[0] == 200
+
+    def test_data_not_stored_locally(self, local_storage):
+        data = self.activity.data()
+        assert data is not None
 
 
 class TestBaseAthlete:
@@ -66,6 +79,10 @@ class TestLocalAthlete:
     def test_get_activity(self, local_athlete):
         activity = local_athlete.get_activity('1970_01_01_00_00_00.csv')
         assert isinstance(activity, models.Activity)
+
+    def test_get_missing_activity(self, local_athlete):
+        activity = local_athlete.get_activity('missing_id')
+        assert activity is None
 
     def test_activities(self, local_athlete):
         activities = local_athlete.activities()

--- a/opendata-python/tests/test_models.py
+++ b/opendata-python/tests/test_models.py
@@ -27,7 +27,7 @@ class TestActivity:
 class TestBaseAthlete:
     def test___init__(self):
         base_athlete = models.BaseAthlete('some-athlete-id-1')
-        
+
         assert base_athlete.id == 'some-athlete-id-1'
 
     def test___eq__(self):
@@ -113,9 +113,22 @@ class TestRemoteAthlete:
         assert f'{{{remote_athlete.id}}}.json' in \
             os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))
 
-    def test_store_locally_no_data(self, remote_athlete, local_storage):
-            remote_athlete.store_locally(data=False)
-            assert remote_athlete.id in \
-                os.listdir(os.path.join(local_storage.strpath, settings.data_prefix))
-            assert f'{{{remote_athlete.id}}}.json' in \
-                os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))
+
+class TestRemoteAthleteLocalStoringOptions:
+    @pytest.fixture
+    def remote_athlete(self):
+        return models.RemoteAthlete('009daa84-3253-4967-93fe-ebdb0fa93339')
+
+    def test_store_locally_with_data(self, remote_athlete, local_storage):
+        remote_athlete.store_locally()
+        assert remote_athlete.id in \
+            os.listdir(os.path.join(local_storage.strpath, settings.data_prefix))
+        assert f'{{{remote_athlete.id}}}.json' in \
+            os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))
+
+    def test_store_locally_wo_data(self, remote_athlete, local_storage):
+        remote_athlete.store_locally(data=False)
+        assert remote_athlete.id not in \
+            os.listdir(os.path.join(local_storage.strpath, settings.data_prefix))
+        assert f'{{{remote_athlete.id}}}.json' in \
+            os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))

--- a/opendata-python/tests/test_models.py
+++ b/opendata-python/tests/test_models.py
@@ -8,8 +8,8 @@ import pytest
 
 
 class TestActivity:
-    def __init__(self, local_storage):
-        self.activity = models.Activity(
+    def test_init(self, local_storage):
+        activity = models.Activity(
             id='1970_01_01_00_00_00.csv',
             filepath_or_buffer=\
                 os.path.join(local_storage.strpath,
@@ -17,10 +17,6 @@ class TestActivity:
                              'some-athlete-id-1',
                              '1970_01_01_00_00_00.csv')
         )
-        return self
-
-    def test_init(self, local_storage):
-        activity = self.activity
         assert activity.id == '1970_01_01_00_00_00.csv'
         assert activity.filepath_or_buffer == \
             os.path.join(local_storage.strpath,
@@ -32,9 +28,16 @@ class TestActivity:
         assert 'heartrate' in activity.data
         assert activity.data.power[0] == 200
 
-    def test_data_not_stored_locally(self, local_storage):
-        data = self.activity.data()
-        assert data is not None
+    def test_init__not_stored_locally(self, local_storage):
+        activity = models.Activity(
+            id='not_stored_activity.csv',
+            filepath_or_buffer=\
+                os.path.join(local_storage.strpath,
+                             settings.data_prefix,
+                             'some-athlete-id-1',
+                             'not_stored_activity.csv')
+        )
+        assert activity is not None
 
 
 class TestBaseAthlete:

--- a/opendata-python/tests/test_models.py
+++ b/opendata-python/tests/test_models.py
@@ -139,19 +139,6 @@ class TestRemoteAthlete:
         assert f'{{{remote_athlete.id}}}.json' in \
             os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))
 
-
-class TestRemoteAthleteLocalStoringOptions:
-    @pytest.fixture
-    def remote_athlete(self):
-        return models.RemoteAthlete('009daa84-3253-4967-93fe-ebdb0fa93339')
-
-    def test_store_locally_with_data(self, remote_athlete, local_storage):
-        remote_athlete.store_locally()
-        assert remote_athlete.id in \
-            os.listdir(os.path.join(local_storage.strpath, settings.data_prefix))
-        assert f'{{{remote_athlete.id}}}.json' in \
-            os.listdir(os.path.join(local_storage.strpath, settings.metadata_prefix))
-
     def test_store_locally_wo_data(self, remote_athlete, local_storage):
         remote_athlete.store_locally(data=False)
         assert remote_athlete.id not in \


### PR DESCRIPTION
The use-case:

I've quickly run off local memory and found it useful to store locally only the metadata of athlete. Implemented by passing an optional flag to `od.store_locally(data=False)`